### PR TITLE
Use query params to add goal processed metrics instead of filter dire…

### DIFF
--- a/core/API/DataTablePostProcessor.php
+++ b/core/API/DataTablePostProcessor.php
@@ -17,6 +17,7 @@ use Piwik\DataTable;
 use Piwik\DataTable\DataTableInterface;
 use Piwik\DataTable\Filter\PivotByDimension;
 use Piwik\Metrics\Formatter;
+use Piwik\Piwik;
 use Piwik\Plugin\ProcessedMetric;
 use Piwik\Plugin\Report;
 use Piwik\Plugin\ReportsProvider;
@@ -256,7 +257,24 @@ class DataTablePostProcessor
         $addGoalProcessedMetrics = null;
         try {
             $addGoalProcessedMetrics = Common::getRequestVar(
-                'filter_update_columns_when_show_all_goals', null, 'integer', $this->request);
+                'filter_update_columns_when_show_all_goals', false, 'string', $this->request);
+            if ((int) $addGoalProcessedMetrics === 0
+                && $addGoalProcessedMetrics !== '0'
+                && $addGoalProcessedMetrics != Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_ORDER
+                && $addGoalProcessedMetrics != Piwik::LABEL_ID_GOAL_IS_ECOMMERCE_CART
+            ) {
+                $addGoalProcessedMetrics = null;
+            }
+        } catch (Exception $ex) {
+            // ignore
+        }
+
+        $goalsToProcess = null;
+        try {
+            $goalsToProcess = Common::getRequestVar('filter_show_goal_columns_process_goals', null, 'string', $this->request);
+            $goalsToProcess = explode(',', $goalsToProcess);
+            $goalsToProcess = array_map('trim', $goalsToProcess);
+            $goalsToProcess = array_filter($goalsToProcess);
         } catch (Exception $ex) {
             // ignore
         }
@@ -265,7 +283,7 @@ class DataTablePostProcessor
             $idGoal = Common::getRequestVar(
                 'idGoal', DataTable\Filter\AddColumnsProcessedMetricsGoal::GOALS_OVERVIEW, 'string', $this->request);
 
-            $dataTable->filter('AddColumnsProcessedMetricsGoal', array($ignore = true, $idGoal));
+            $dataTable->filter('AddColumnsProcessedMetricsGoal', array($ignore = true, $idGoal, $goalsToProcess));
         }
 
         return $dataTable;

--- a/plugins/Goals/Visualizations/Goals.php
+++ b/plugins/Goals/Visualizations/Goals.php
@@ -88,7 +88,8 @@ class Goals extends HtmlTable
         }
 
         // add goals columns
-        $this->config->filters[] = array('AddColumnsProcessedMetricsGoal', array($enable = true, $idGoal, $goalsToProcess), $priority = true);
+        $this->requestConfig->request_parameters_to_modify['filter_update_columns_when_show_all_goals'] = $idGoal;
+        $this->requestConfig->request_parameters_to_modify['filter_show_goal_columns_process_goals'] = implode(',', $goalsToProcess);
     }
 
     private function setPropertiesForEcommerceView()


### PR DESCRIPTION
…ctly. (#14465)

* Use query params to add goal processed metrics instead of filter directly.

* Fix goal validation for filter_update_columns_when_show_all_goals param.

* Fix another test.